### PR TITLE
Add open/close handler to Wspp_Wrapper. Add close function to Wspp_wr…

### DIFF
--- a/demo_src/publish_example.cpp
+++ b/demo_src/publish_example.cpp
@@ -8,7 +8,7 @@ int main(int argc, char const *argv[]) {
 	crb_sock::WsppWrapper sock;
 	double t_last_adv = 0;
 	//sock.connect("127.0.0.1", 9090);
-	std::cout <<"connect:"<< sock.connect("ws://0.0.0.0:9090") << std::endl;
+	std::cout <<"connect:"<< sock.connect("ws://127.0.0.1:9090") << std::endl;
 	crb_client::ConnectionManager<crb_sock::WsppWrapper> cm(&sock);
 	std::chrono::system_clock::time_point program_start, current_time;
 	/*
@@ -34,7 +34,7 @@ int main(int argc, char const *argv[]) {
 	op_json2 = json_object();
 	json_object_set_new(op_json2, "data", json_real(1.5));
 
-	for(;;)
+	for(int kuriyama = 0; kuriyama < 10; kuriyama++)
 	{
 		double t_from_start;
 		current_time = std::chrono::system_clock::now();
@@ -44,7 +44,7 @@ int main(int argc, char const *argv[]) {
 		//if(t_from_start > 100000) break;
 		if(true)//t_from_start - t_last_adv >= 100)
 		{
-			std::cout << t_from_start << ":";
+			std::cout << t_from_start << ":" << std::endl;
 			//cm.advertise("testtopic", "std_msgs/Int64");
 			cm.publish("testtopic", *op_json);
 			cm.publish("testtopic2", *op_json2);

--- a/inc/wspp_wrapper.hpp
+++ b/inc/wspp_wrapper.hpp
@@ -18,6 +18,9 @@ public:
 	int sendStr(const std::string &str);
 	int setRecieveCb(SockCallback_t cb);
 
+    //kuriyama
+    void close();
+
 private:
 	SockCallback_t _callbk;
 	//std::function<void(websocketpp::connection_hdl, wspp_client_t::message_ptr)> _on_message;
@@ -26,6 +29,11 @@ private:
 	wspp_client_t::connection_ptr _con;
 	websocketpp::connection_hdl hdl;
 	websocketpp::lib::shared_ptr<websocketpp::lib::thread> m_thread;
+
+    //kuriyama
+	void _on_fail(wspp_client_t *c, websocketpp::connection_hdl hdl_);
+	void _on_open(wspp_client_t *c, websocketpp::connection_hdl hdl_);
+    std::string m_status;
 };
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(websocketpp)
+#find_package(websocketpp)
 find_package(Boost)
 
 add_library(wspp_wrapper


### PR DESCRIPTION
…apper. Modify a destructor of Wspp_wrapper.
編集履歴：
＊endpoint を閉じる処理や、m_thread->join 等の処理がコメントアウトされていた。コメントアウトを外してもエラー。
＊websocketpp のチュートリアルを基に、endpoint のclose関数追加、デストラクターの修正、m_thread->join 周りを改善。
＊付随して、メンバー変数にm_statusを追加し、open/close handler を追加。
＊demo_src/publish_example は、テスト用に固定回数ループに変更した。